### PR TITLE
Migration to Gradle version catalog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ out/
 
 ### VS Code ###
 .vscode/
+/versions.properties

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,12 +1,7 @@
-val ktor_version: String by project
-val kotlin_version: String by project
-val logback_version: String by project
-val exposedVersion: String by project
-
 plugins {
-    kotlin("jvm") version "1.8.21"
-    id("io.ktor.plugin") version "2.3.0"
-    id("org.jetbrains.kotlin.plugin.serialization") version "1.8.21"
+    alias(libs.plugins.org.jetbrains.kotlin.jvm)
+    alias(libs.plugins.io.ktor.plugin)
+    alias(libs.plugins.org.jetbrains.kotlin.plugin.serialization)
 }
 
 group = "io.ktor.answers"
@@ -23,23 +18,23 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-server-core-jvm:$ktor_version")
-    implementation("io.ktor:ktor-server-content-negotiation-jvm:$ktor_version")
-    implementation("io.ktor:ktor-serialization-kotlinx-json-jvm:$ktor_version")
-    implementation("io.ktor:ktor-server-host-common-jvm:$ktor_version")
-    implementation("io.ktor:ktor-server-status-pages-jvm:$ktor_version")
-    implementation("io.ktor:ktor-server-netty-jvm:$ktor_version")
-    implementation("ch.qos.logback:logback-classic:$logback_version")
-    implementation("org.jetbrains.exposed:exposed-core:$exposedVersion")
-    implementation("org.jetbrains.exposed:exposed-dao:$exposedVersion")
-    implementation("org.jetbrains.exposed:exposed-jdbc:$exposedVersion")
-    implementation("org.jetbrains.exposed:exposed-kotlin-datetime:$exposedVersion")
-    implementation("org.liquibase:liquibase-core:4.21.1")
-    runtimeOnly("org.postgresql:postgresql:42.6.0")
+    implementation(libs.ktor.server.core.jvm)
+    implementation(libs.ktor.server.content.negotiation.jvm)
+    implementation(libs.ktor.serialization.kotlinx.json.jvm)
+    implementation(libs.ktor.server.host.common.jvm)
+    implementation(libs.ktor.server.status.pages.jvm)
+    implementation(libs.ktor.server.netty.jvm)
+    implementation(libs.logback.classic)
+    implementation(libs.exposed.core)
+    implementation(libs.exposed.dao)
+    implementation(libs.exposed.jdbc)
+    implementation(libs.exposed.kotlin.datetime)
+    implementation(libs.liquibase)
+    runtimeOnly(libs.postgres)
     testImplementation(kotlin("test"))
-    testImplementation("io.ktor:ktor-server-tests-jvm:$ktor_version")
-    testImplementation("org.testcontainers:postgresql:1.18.0")
-    testImplementation("org.testcontainers:junit-jupiter:1.18.0")
+    testImplementation(libs.ktor.server.tests.jvm)
+    testImplementation(libs.testcontainers.postgres)
+    testImplementation(libs.testcontainers.jupiter)
 }
 
 tasks.test {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,59 @@
+[plugins]
+
+org-jetbrains-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+
+io-ktor-plugin = { id = "io.ktor.plugin", version.ref = "ktor" }
+
+org-jetbrains-kotlin-plugin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+
+[versions]
+
+kotlin = "1.8.21"
+
+ktor = "2.3.0"
+
+exposed = "0.41.1"
+
+testcontainers = "1.18.0"
+
+[libraries]
+
+ktor-bom = { group = "io.ktor", name = "ktor-bom", version.ref = "ktor" }
+
+ktor-server-core-jvm = { group = "io.ktor", name = "ktor-server-core-jvm", version.ref = "ktor" }
+
+ktor-server-content-negotiation-jvm = { group = "io.ktor", name = "ktor-server-content-negotiation-jvm", version.ref = "ktor" }
+
+ktor-serialization-kotlinx-json-jvm = { group = "io.ktor", name = "ktor-serialization-kotlinx-json-jvm", version.ref = "ktor" }
+
+ktor-server-host-common-jvm = { group = "io.ktor", name = "ktor-server-host-common-jvm", version.ref = "ktor" }
+
+ktor-server-status-pages-jvm = { group = "io.ktor", name = "ktor-server-status-pages-jvm", version.ref = "ktor" }
+
+ktor-server-netty-jvm = { group = "io.ktor", name = "ktor-server-netty-jvm", version.ref = "ktor" }
+
+logback-classic = "ch.qos.logback:logback-classic:1.4.7"
+
+exposed-core = { group = "org.jetbrains.exposed", name = "exposed-core", version.ref = "exposed" }
+
+exposed-dao = { group = "org.jetbrains.exposed", name = "exposed-dao", version.ref = "exposed" }
+
+exposed-jdbc = { group = "org.jetbrains.exposed", name = "exposed-jdbc", version.ref = "exposed" }
+
+exposed-kotlin-datetime = { group = "org.jetbrains.exposed", name = "exposed-kotlin-datetime", version.ref = "exposed" }
+
+liquibase = "org.liquibase:liquibase-core:4.21.1"
+
+postgres = "org.postgresql:postgresql:42.6.0"
+
+kotlin-scripting-compiler-embeddable = { group = "org.jetbrains.kotlin", name = "kotlin-scripting-compiler-embeddable", version.ref = "kotlin" }
+
+kotlin-serialization = { group = "org.jetbrains.kotlin", name = "kotlin-serialization", version.ref = "kotlin" }
+
+kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test" }
+
+ktor-server-tests-jvm = { group = "io.ktor", name = "ktor-server-tests-jvm", version.ref = "ktor" }
+
+testcontainers-postgres = { group = "org.testcontainers", name = "postgresql", version.ref = "testcontainers" }
+
+testcontainers-jupiter = { group = "org.testcontainers", name = "junit-jupiter", version.ref = "testcontainers" }

--- a/src/main/kotlin/io/ktor/answers/Application.kt
+++ b/src/main/kotlin/io/ktor/answers/Application.kt
@@ -1,12 +1,13 @@
 package io.ktor.answers
 
-import io.ktor.server.application.*
-import io.ktor.server.engine.*
-import io.ktor.server.netty.*
 import io.ktor.answers.plugins.*
-import liquibase.Contexts
-import liquibase.LabelExpression
+import io.ktor.server.application.*
 import liquibase.Liquibase
+import liquibase.Scope
+import liquibase.command.CommandScope
+import liquibase.command.core.UpdateCommandStep.CHANGELOG_FILE_ARG
+import liquibase.command.core.UpdateCommandStep.COMMAND_NAME
+import liquibase.command.core.helpers.DbUrlConnectionCommandStep.DATABASE_ARG
 import liquibase.database.DatabaseFactory
 import liquibase.database.jvm.JdbcConnection
 import liquibase.resource.ClassLoaderResourceAccessor
@@ -14,16 +15,34 @@ import java.sql.DriverManager
 
 
 fun Application.module() {
-    val jdbcUrl = environment.config.property("database.url").getString()
-    val username = environment.config.property("database.username").getString()
-    val password = environment.config.property("database.password").getString()
-    val database =
-        DatabaseFactory.getInstance()
-            .findCorrectDatabaseImplementation(JdbcConnection(DriverManager.getConnection(jdbcUrl, username, password)))
-    val liquibase = Liquibase("db/changelog/changelog.xml", ClassLoaderResourceAccessor(), database)
-    liquibase.dropAll()
-    liquibase.update(Contexts(""), LabelExpression(), true)
-
+    migrateDb()
     configureSerialization()
     configureRouting()
+}
+
+fun Application.migrateDb() = with(environment.config) {
+    migrate(
+        property("database.url").getString(),
+        property("database.username").getString(),
+        property("database.password").getString()
+    )
+}
+
+fun migrate(jdbcUrl: String, username: String, password: String, drop: Boolean = false) {
+    Scope.child(mapOf()) {
+        val database =
+            DatabaseFactory
+                .getInstance()
+                .findCorrectDatabaseImplementation(
+                    JdbcConnection(DriverManager.getConnection(jdbcUrl, username, password))
+                )
+        val liquibase = Liquibase("db/changelog/changelog.xml", ClassLoaderResourceAccessor(), database)
+        if (drop)
+            liquibase.dropAll()
+        CommandScope(*COMMAND_NAME).apply {
+            addArgumentValue(DATABASE_ARG, database)
+            addArgumentValue(CHANGELOG_FILE_ARG, "db/changelog/changelog.xml")
+            execute()
+        }
+    }
 }

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -9,4 +9,8 @@
     </root>
     <logger name="org.eclipse.jetty" level="INFO"/>
     <logger name="io.netty" level="INFO"/>
+    <logger name="org.testcontainers" level="INFO"/>
+    <logger name="tc" level="INFO"/>
+    <logger name="com.github.dockerjava" level="WARN"/>
+    <logger name="com.github.dockerjava.zerodep.shaded.org.apache.hc.client5.http.wire" level="OFF"/>
 </configuration>

--- a/src/test/kotlin/io/ktor/answers/AbstractDbTest.kt
+++ b/src/test/kotlin/io/ktor/answers/AbstractDbTest.kt
@@ -1,0 +1,20 @@
+package io.ktor.answers
+
+import org.jetbrains.exposed.sql.Database
+import org.testcontainers.containers.PostgreSQLContainer
+
+abstract class AbstractDbTest {
+    companion object {
+        @JvmField
+        var postgres = PostgreSQLContainer("postgres")
+
+        init {
+            postgres.start()
+            val url = postgres.jdbcUrl
+            val user = postgres.username
+            val password = postgres.password
+            migrate(url, user, password)
+            Database.connect(url, user = user, password = password)
+        }
+    }
+}

--- a/src/test/kotlin/io/ktor/answers/ApplicationTest.kt
+++ b/src/test/kotlin/io/ktor/answers/ApplicationTest.kt
@@ -6,11 +6,20 @@ import io.ktor.server.testing.*
 import kotlin.test.*
 import io.ktor.http.*
 import io.ktor.answers.plugins.*
+import io.ktor.server.config.*
 
-class ApplicationTest {
+class ApplicationTest : AbstractDbTest() {
     @Test
     fun testRoot() = testApplication {
+        environment {
+            config = MapApplicationConfig(
+                "database.url" to postgres.jdbcUrl,
+                "database.username" to postgres.username,
+                "database.password" to postgres.password
+            )
+        }
         application {
+            migrateDb()
             configureRouting()
         }
         client.get("/").apply {


### PR DESCRIPTION
- Starting domain
- Adds simplistic exposed domain and runs
- Let's add some analytics
- Adds tags support
- Moves dao and schema to different files, changes vote to short
- Adds tests and migration
- Adds liquibase migration to the application start
- Migrates to gradle version catalog
